### PR TITLE
Фикс автопушки Ми-28

### DIFF
--- a/src/main/resources/data/vvp/sbw/vehicles/mi_28.json
+++ b/src/main/resources/data/vvp/sbw/vehicles/mi_28.json
@@ -85,7 +85,7 @@
       "DefaultFireMode": "Auto",
       "AvailableFireModes": "Auto",
       "Projectile": "superbwarfare:small_cannon_shell",
-      "Icon": "vvp:textures/screens/vehicle_weapon/20_mm.png",
+      "Icon": "vvp:textures/screens/vehicle_weapon/30_mm.png",
       "DefaultZoom": 3,
       "RPM": 300,
       "Velocity": 30,
@@ -108,7 +108,7 @@
       "Crosshair": "@VehicleCommonGunDynamic",
       "CrosshairColor": "0xFFC700",
       "SoundRadius": 24,
-      "AmmoType": "vvp:item_20_mm",
+      "AmmoType": "vvp:item_30mm",
       "ShootPos": {
         "Transform": "Barrel",
         "Positions": [[0, -0.3, 3.1]],


### PR DESCRIPTION
В файле
https://github.com/sergeyrendo/vvp-sourve/blob/07ef11a5a8b0923f2c74d0575a0dc51f65b1c695/src/main/resources/data/vvp/sbw/vehicles/mi_28.json#L111

В строке 88 стоит  "Icon": "vvp:textures/screens/vehicle_weapon/20_mm.png", (вместо 30мм которые у 2А42)
а в строке 111стоит  "AmmoType": "vvp:item_20_mm", что не позволяет использовать автопушку из-за несуществующего предмета, а так же вызывает спам в консоли на стороне сервера: invalid ammo string vvp:item_20_mm for  ; invalid item: vvp:item_20_mm.
Исправил тип боеприпасов на 30мм снаряд из мода и корректное отображение калибра боеприпаса